### PR TITLE
handle "killed by SIGPIPE" message

### DIFF
--- a/src/flametrace/core.py
+++ b/src/flametrace/core.py
@@ -46,6 +46,8 @@ class StraceParser(object):
         if call.startswith("+++ exited with "):
             retcode = int(call[len("+++ exited with ") :].split()[0])
             return "atexit", None, retcode, None, None
+        elif call == "+++ killed by SIGPIPE +++":
+            return "atexit", None, 128 + 13, None, None
         elif call.startswith("--- "):
             rest = call[len("--- ") :]
             signal, rest = rest.split(" ", 1)


### PR DESCRIPTION
Some versions of strace emit a special message `+++ killed by SIGPIPE +++` that confuse our parser. They're mostly harmless, we can ignore them and the rest of the output makes sense.